### PR TITLE
Added options to compile against Qt6 for debian

### DIFF
--- a/debian/libkdsoap-bin.install
+++ b/debian/libkdsoap-bin.install
@@ -1,1 +1,1 @@
-usr/bin/kdwsdl2cpp
+usr/bin/kdwsdl2cpp-qt6

--- a/debian/libkdsoap-dev.install
+++ b/debian/libkdsoap-dev.install
@@ -1,11 +1,10 @@
-usr/include/KDSoapClient/*
-usr/include/KDSoapServer/*
-usr/lib/*/libkdsoap.so
-usr/lib/*/libkdsoap-server.so
-usr/lib/*/cmake/KDSoap/KDSoapConfig.cmake
-usr/lib/*/cmake/KDSoap/KDSoapConfigVersion.cmake
-usr/lib/*/cmake/KDSoap/KDSoapMacros.cmake
-usr/lib/*/cmake/KDSoap/KDSoapTargets.cmake
-usr/lib/*/cmake/KDSoap/KDSoapTargets-debug.cmake
-usr/share/mkspecs/features/kdsoap.prf usr/lib/${DEB_HOST_MULTIARCH}/qt5/mkspecs/features/
-usr/lib/*/qt5/mkspecs/modules/*
+usr/include/KDSoapClient-Qt6/*
+usr/include/KDSoapServer-Qt6/*
+usr/lib/*/libkdsoap-qt6.so
+usr/lib/*/libkdsoap-server-qt6.so
+usr/lib/*/cmake/KDSoap-qt6/KDSoap-qt6Config.cmake
+usr/lib/*/cmake/KDSoap-qt6/KDSoap-qt6ConfigVersion.cmake
+usr/lib/*/cmake/KDSoap-qt6/KDSoapMacros.cmake
+usr/lib/*/cmake/KDSoap-qt6/KDSoapTargets.cmake
+usr/lib/*/cmake/KDSoap-qt6/KDSoapTargets-debug.cmake
+usr/lib/*/qt6/mkspecs/modules/*

--- a/debian/libkdsoap-doc.examples
+++ b/debian/libkdsoap-doc.examples
@@ -1,2 +1,2 @@
 examples/*
-usr/share/doc/KDSoap/*.pri
+usr/share/doc/KDSoap-qt6/*

--- a/debian/libkdsoap-server2.install
+++ b/debian/libkdsoap-server2.install
@@ -1,1 +1,2 @@
-usr/lib/*/libkdsoap-server.so.*
+usr/lib/*/libkdsoap-server-qt6.*
+

--- a/debian/libkdsoap2.install
+++ b/debian/libkdsoap2.install
@@ -1,1 +1,2 @@
-usr/lib/*/libkdsoap.so.*
+usr/lib/*/libkdsoap-qt6.*
+

--- a/debian/rules
+++ b/debian/rules
@@ -6,4 +6,5 @@
 override_dh_auto_configure:
 	dh_auto_configure -- \
 	-DCMAKE_BUILD_TYPE=Debug \
-	-DCMAKE_INSTALL_PREFIX=/usr
+	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DKDSoap_QT6=true


### PR DESCRIPTION
Hi,
i changed rules and the other file into debian directory, to compile against Qt6 and not Qt5, your version is compiled against qt5 module, so kio-extras try to find qt5 modules and not qt6. 

